### PR TITLE
v0.14.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Add this dependency to your project's POM:
 <dependency>
   <groupId>com.mux</groupId>
   <artifactId>mux-sdk-java</artifactId>
-  <version>0.13.0</version>
+  <version>0.14.0</version>
   <scope>compile</scope>
 </dependency>
 ```
@@ -58,7 +58,7 @@ Add this dependency to your project's POM:
 Add this dependency to your project's build file:
 
 ```groovy
-compile "com.mux:mux-sdk-java:0.13.0"
+compile "com.mux:mux-sdk-java:0.14.0"
 ```
 
 ### Others
@@ -71,7 +71,7 @@ mvn clean package
 
 Then manually install the following JARs:
 
-* `target/mux-sdk-java-0.13.0.jar`
+* `target/mux-sdk-java-0.14.0.jar`
 * `target/lib/*.jar`
 
 ## Getting Started
@@ -99,7 +99,7 @@ public class Example {
     accessToken.setPassword("YOUR PASSWORD");
 
     AssetsApi apiInstance = new AssetsApi(defaultClient);
-    CreateAssetRequest createAssetRequest = {"input":[{"url":"https://muxed.s3.amazonaws.com/leds.mp4"}],"playback_policy":["public"],"encoding_tier":"baseline"}; // CreateAssetRequest | 
+    CreateAssetRequest createAssetRequest = {"input":[{"url":"https://muxed.s3.amazonaws.com/leds.mp4"}],"playback_policy":["public"],"video_quality":"basic"}; // CreateAssetRequest | 
     try {
       AssetResponse result = apiInstance.createAsset(createAssetRequest)
             .execute();

--- a/build.gradle
+++ b/build.gradle
@@ -16,7 +16,7 @@ plugins {
 }
 
 group = 'com.mux'
-version = '0.13.0'
+version = '0.14.0'
 
 repositories {
     mavenCentral()

--- a/docs/Asset.md
+++ b/docs/Asset.md
@@ -13,7 +13,8 @@ Name | Type | Description | Notes
 **maxStoredResolution** | [**MaxStoredResolutionEnum**](#MaxStoredResolutionEnum) | This field is deprecated. Please use &#x60;resolution_tier&#x60; instead. The maximum resolution that has been stored for the asset. The asset may be delivered at lower resolutions depending on the device and bandwidth, however it cannot be delivered at a higher value than is stored. |  [optional]
 **resolutionTier** | [**ResolutionTierEnum**](#ResolutionTierEnum) | The resolution tier that the asset was ingested at, affecting billing for ingest &amp; storage. This field also represents the highest resolution tier that the content can be delivered at, however the actual resolution may be lower depending on the device, bandwidth, and exact resolution of the uploaded asset. |  [optional]
 **maxResolutionTier** | [**MaxResolutionTierEnum**](#MaxResolutionTierEnum) | Max resolution tier can be used to control the maximum &#x60;resolution_tier&#x60; your asset is encoded, stored, and streamed at. If not set, this defaults to &#x60;1080p&#x60;. |  [optional]
-**encodingTier** | [**EncodingTierEnum**](#EncodingTierEnum) | The encoding tier informs the cost, quality, and available platform features for the asset. By default the &#x60;smart&#x60; encoding tier is used. [See the guide for more details.](https://docs.mux.com/guides/use-encoding-tiers) |  [optional]
+**encodingTier** | [**EncodingTierEnum**](#EncodingTierEnum) | This field is deprecated. Please use &#x60;video_quality&#x60; instead. The encoding tier informs the cost, quality, and available platform features for the asset. By default the &#x60;smart&#x60; encoding tier is used. [See the video quality guide for more details.](https://docs.mux.com/guides/use-encoding-tiers) |  [optional]
+**videoQuality** | [**VideoQualityEnum**](#VideoQualityEnum) | The video quality controls the cost, quality, and available platform features for the asset. By default the &#x60;plus&#x60; video quality is used. This field replaces the deprecated &#x60;encoding_tier&#x60; value. [See the video quality guide for more details.](https://docs.mux.com/guides/use-encoding-tiers) |  [optional]
 **maxStoredFrameRate** | **Double** | The maximum frame rate that has been stored for the asset. The asset may be delivered at lower frame rates depending on the device and bandwidth, however it cannot be delivered at a higher value than is stored. This field may return -1 if the frame rate of the input cannot be reliably determined. |  [optional]
 **aspectRatio** | **String** | The aspect ratio of the asset in the form of &#x60;width:height&#x60;, for example &#x60;16:9&#x60;. |  [optional]
 **playbackIds** | [**java.util.List&lt;PlaybackID&gt;**](PlaybackID.md) | An array of Playback ID objects. Use these to create HLS playback URLs. See [Play your videos](https://docs.mux.com/guides/play-your-videos) for more details. |  [optional]
@@ -87,6 +88,15 @@ Name | Value
 ---- | -----
 SMART | &quot;smart&quot;
 BASELINE | &quot;baseline&quot;
+
+
+
+## Enum: VideoQualityEnum
+
+Name | Value
+---- | -----
+BASIC | &quot;basic&quot;
+PLUS | &quot;plus&quot;
 
 
 

--- a/docs/AssetsApi.md
+++ b/docs/AssetsApi.md
@@ -49,7 +49,7 @@ public class Example {
     accessToken.setPassword("YOUR PASSWORD");
 
     AssetsApi apiInstance = new AssetsApi(defaultClient);
-    CreateAssetRequest createAssetRequest = {"input":[{"url":"https://muxed.s3.amazonaws.com/leds.mp4"}],"playback_policy":["public"],"encoding_tier":"baseline"}; // CreateAssetRequest | 
+    CreateAssetRequest createAssetRequest = {"input":[{"url":"https://muxed.s3.amazonaws.com/leds.mp4"}],"playback_policy":["public"],"video_quality":"basic"}; // CreateAssetRequest | 
     try {
       AssetResponse result = apiInstance.createAsset(createAssetRequest)
             .execute();

--- a/docs/CreateAssetRequest.md
+++ b/docs/CreateAssetRequest.md
@@ -16,7 +16,8 @@ Name | Type | Description | Notes
 **masterAccess** | [**MasterAccessEnum**](#MasterAccessEnum) | Specify what level (if any) of support for master access. Master access can be enabled temporarily for your asset to be downloaded. See the [Download your videos guide](https://docs.mux.com/guides/enable-static-mp4-renditions) for more information. |  [optional]
 **test** | **Boolean** | Marks the asset as a test asset when the value is set to true. A Test asset can help evaluate the Mux Video APIs without incurring any cost. There is no limit on number of test assets created. Test asset are watermarked with the Mux logo, limited to 10 seconds, deleted after 24 hrs. |  [optional]
 **maxResolutionTier** | [**MaxResolutionTierEnum**](#MaxResolutionTierEnum) | Max resolution tier can be used to control the maximum &#x60;resolution_tier&#x60; your asset is encoded, stored, and streamed at. If not set, this defaults to &#x60;1080p&#x60;. |  [optional]
-**encodingTier** | [**EncodingTierEnum**](#EncodingTierEnum) | The encoding tier informs the cost, quality, and available platform features for the asset. By default the &#x60;smart&#x60; encoding tier is used. [See the guide for more details.](https://docs.mux.com/guides/use-encoding-tiers) |  [optional]
+**encodingTier** | [**EncodingTierEnum**](#EncodingTierEnum) | This field is deprecated. Please use &#x60;video_quality&#x60; instead. The encoding tier informs the cost, quality, and available platform features for the asset. By default the &#x60;smart&#x60; encoding tier is used. [See the video quality guide for more details.](https://docs.mux.com/guides/use-encoding-tiers) |  [optional]
+**videoQuality** | [**VideoQualityEnum**](#VideoQualityEnum) | The video quality controls the cost, quality, and available platform features for the asset. By default the &#x60;plus&#x60; video quality is used. This field replaces the deprecated &#x60;encoding_tier&#x60; value. [See the video quality guide for more details.](https://docs.mux.com/guides/use-encoding-tiers) |  [optional]
 
 
 
@@ -57,6 +58,15 @@ Name | Value
 ---- | -----
 SMART | &quot;smart&quot;
 BASELINE | &quot;baseline&quot;
+
+
+
+## Enum: VideoQualityEnum
+
+Name | Value
+---- | -----
+BASIC | &quot;basic&quot;
+PLUS | &quot;plus&quot;
 
 
 

--- a/docs/DeliveryReport.md
+++ b/docs/DeliveryReport.md
@@ -14,7 +14,8 @@ Name | Type | Description | Notes
 **assetState** | [**AssetStateEnum**](#AssetStateEnum) | The state of the asset. |  [optional]
 **assetDuration** | **Double** | The duration of the asset in seconds. |  [optional]
 **assetResolutionTier** | [**AssetResolutionTierEnum**](#AssetResolutionTierEnum) | The resolution tier that the asset was ingested at, affecting billing for ingest &amp; storage |  [optional]
-**assetEncodingTier** | [**AssetEncodingTierEnum**](#AssetEncodingTierEnum) | The encoding tier that the asset was ingested at. [See the encoding tiers guide for more details.](https://docs.mux.com/guides/use-encoding-tiers) |  [optional]
+**assetEncodingTier** | [**AssetEncodingTierEnum**](#AssetEncodingTierEnum) | This field is deprecated. Please use &#x60;asset_video_quality&#x60; instead. The encoding tier that the asset was ingested at. [See the video quality guide for more details.](https://docs.mux.com/guides/use-encoding-tiers) |  [optional]
+**assetVideoQuality** | [**AssetVideoQualityEnum**](#AssetVideoQualityEnum) | The video quality that the asset was ingested at. This field replaces &#x60;asset_encoding_tier&#x60;. [See the video quality guide for more details.](https://docs.mux.com/guides/use-encoding-tiers) |  [optional]
 **deliveredSeconds** | **Double** | Total number of delivered seconds during this time window. |  [optional]
 **deliveredSecondsByResolution** | [**DeliveryReportDeliveredSecondsByResolution**](DeliveryReportDeliveredSecondsByResolution.md) |  |  [optional]
 
@@ -48,6 +49,15 @@ Name | Value
 ---- | -----
 SMART | &quot;smart&quot;
 BASELINE | &quot;baseline&quot;
+
+
+
+## Enum: AssetVideoQualityEnum
+
+Name | Value
+---- | -----
+BASIC | &quot;basic&quot;
+PLUS | &quot;plus&quot;
 
 
 

--- a/gen/generator-config.json
+++ b/gen/generator-config.json
@@ -1,6 +1,6 @@
 {
   "!!source": "https://github.com/OpenAPITools/openapi-generator/blob/master/docs/generators/java.md",
-    "artifactVersion": "0.13.0",
+    "artifactVersion": "0.14.0",
   "apiPackage": "com.mux.sdk",
   "artifactDescription": "Mux SDK for Java",
   "artifactId": "mux-sdk-java",

--- a/src/main/java/com/mux/ApiClient.java
+++ b/src/main/java/com/mux/ApiClient.java
@@ -123,7 +123,7 @@ public class ApiClient {
         json = new JSON();
 
         // Set default User-Agent.
-        setUserAgent("Mux Java | 0.13.0");
+        setUserAgent("Mux Java | 0.14.0");
 
         authentications = new HashMap<String, Authentication>();
     }

--- a/src/main/java/com/mux/sdk/models/Asset.java
+++ b/src/main/java/com/mux/sdk/models/Asset.java
@@ -269,7 +269,7 @@ public class Asset {
   private MaxResolutionTierEnum maxResolutionTier;
 
   /**
-   * The encoding tier informs the cost, quality, and available platform features for the asset. By default the &#x60;smart&#x60; encoding tier is used. [See the guide for more details.](https://docs.mux.com/guides/use-encoding-tiers)
+   * This field is deprecated. Please use &#x60;video_quality&#x60; instead. The encoding tier informs the cost, quality, and available platform features for the asset. By default the &#x60;smart&#x60; encoding tier is used. [See the video quality guide for more details.](https://docs.mux.com/guides/use-encoding-tiers)
    */
   @JsonAdapter(EncodingTierEnum.Adapter.class)
   public enum EncodingTierEnum {
@@ -318,6 +318,57 @@ public class Asset {
   public static final String SERIALIZED_NAME_ENCODING_TIER = "encoding_tier";
   @SerializedName(SERIALIZED_NAME_ENCODING_TIER)
   private EncodingTierEnum encodingTier;
+
+  /**
+   * The video quality controls the cost, quality, and available platform features for the asset. By default the &#x60;plus&#x60; video quality is used. This field replaces the deprecated &#x60;encoding_tier&#x60; value. [See the video quality guide for more details.](https://docs.mux.com/guides/use-encoding-tiers)
+   */
+  @JsonAdapter(VideoQualityEnum.Adapter.class)
+  public enum VideoQualityEnum {
+    BASIC("basic"),
+    
+    PLUS("plus");
+
+    private String value;
+
+    VideoQualityEnum(String value) {
+      this.value = value;
+    }
+
+    public String getValue() {
+      return value;
+    }
+
+    @Override
+    public String toString() {
+      return String.valueOf(value);
+    }
+
+    public static VideoQualityEnum fromValue(String value) {
+      for (VideoQualityEnum b : VideoQualityEnum.values()) {
+        if (b.value.equals(value)) {
+          return b;
+        }
+      }
+      throw new IllegalArgumentException("Unexpected value '" + value + "'");
+    }
+
+    public static class Adapter extends TypeAdapter<VideoQualityEnum> {
+      @Override
+      public void write(final JsonWriter jsonWriter, final VideoQualityEnum enumeration) throws IOException {
+        jsonWriter.value(enumeration.getValue());
+      }
+
+      @Override
+      public VideoQualityEnum read(final JsonReader jsonReader) throws IOException {
+        String value =  jsonReader.nextString();
+        return VideoQualityEnum.fromValue(value);
+      }
+    }
+  }
+
+  public static final String SERIALIZED_NAME_VIDEO_QUALITY = "video_quality";
+  @SerializedName(SERIALIZED_NAME_VIDEO_QUALITY)
+  private VideoQualityEnum videoQuality;
 
   public static final String SERIALIZED_NAME_MAX_STORED_FRAME_RATE = "max_stored_frame_rate";
   @SerializedName(SERIALIZED_NAME_MAX_STORED_FRAME_RATE)
@@ -721,11 +772,11 @@ public class Asset {
   }
 
    /**
-   * The encoding tier informs the cost, quality, and available platform features for the asset. By default the &#x60;smart&#x60; encoding tier is used. [See the guide for more details.](https://docs.mux.com/guides/use-encoding-tiers)
+   * This field is deprecated. Please use &#x60;video_quality&#x60; instead. The encoding tier informs the cost, quality, and available platform features for the asset. By default the &#x60;smart&#x60; encoding tier is used. [See the video quality guide for more details.](https://docs.mux.com/guides/use-encoding-tiers)
    * @return encodingTier
   **/
   @javax.annotation.Nullable
-  @ApiModelProperty(value = "The encoding tier informs the cost, quality, and available platform features for the asset. By default the `smart` encoding tier is used. [See the guide for more details.](https://docs.mux.com/guides/use-encoding-tiers)")
+  @ApiModelProperty(value = "This field is deprecated. Please use `video_quality` instead. The encoding tier informs the cost, quality, and available platform features for the asset. By default the `smart` encoding tier is used. [See the video quality guide for more details.](https://docs.mux.com/guides/use-encoding-tiers)")
 
   public EncodingTierEnum getEncodingTier() {
     return encodingTier;
@@ -734,6 +785,29 @@ public class Asset {
 
   public void setEncodingTier(EncodingTierEnum encodingTier) {
     this.encodingTier = encodingTier;
+  }
+
+
+  public Asset videoQuality(VideoQualityEnum videoQuality) {
+    
+    this.videoQuality = videoQuality;
+    return this;
+  }
+
+   /**
+   * The video quality controls the cost, quality, and available platform features for the asset. By default the &#x60;plus&#x60; video quality is used. This field replaces the deprecated &#x60;encoding_tier&#x60; value. [See the video quality guide for more details.](https://docs.mux.com/guides/use-encoding-tiers)
+   * @return videoQuality
+  **/
+  @javax.annotation.Nullable
+  @ApiModelProperty(value = "The video quality controls the cost, quality, and available platform features for the asset. By default the `plus` video quality is used. This field replaces the deprecated `encoding_tier` value. [See the video quality guide for more details.](https://docs.mux.com/guides/use-encoding-tiers)")
+
+  public VideoQualityEnum getVideoQuality() {
+    return videoQuality;
+  }
+
+
+  public void setVideoQuality(VideoQualityEnum videoQuality) {
+    this.videoQuality = videoQuality;
   }
 
 
@@ -1238,6 +1312,7 @@ public class Asset {
         Objects.equals(this.resolutionTier, asset.resolutionTier) &&
         Objects.equals(this.maxResolutionTier, asset.maxResolutionTier) &&
         Objects.equals(this.encodingTier, asset.encodingTier) &&
+        Objects.equals(this.videoQuality, asset.videoQuality) &&
         Objects.equals(this.maxStoredFrameRate, asset.maxStoredFrameRate) &&
         Objects.equals(this.aspectRatio, asset.aspectRatio) &&
         Objects.equals(this.playbackIds, asset.playbackIds) &&
@@ -1262,7 +1337,7 @@ public class Asset {
 
   @Override
   public int hashCode() {
-    return Objects.hash(id, createdAt, status, duration, maxStoredResolution, resolutionTier, maxResolutionTier, encodingTier, maxStoredFrameRate, aspectRatio, playbackIds, tracks, errors, perTitleEncode, uploadId, isLive, passthrough, liveStreamId, master, masterAccess, mp4Support, sourceAssetId, normalizeAudio, staticRenditions, recordingTimes, nonStandardInputReasons, test, ingestType);
+    return Objects.hash(id, createdAt, status, duration, maxStoredResolution, resolutionTier, maxResolutionTier, encodingTier, videoQuality, maxStoredFrameRate, aspectRatio, playbackIds, tracks, errors, perTitleEncode, uploadId, isLive, passthrough, liveStreamId, master, masterAccess, mp4Support, sourceAssetId, normalizeAudio, staticRenditions, recordingTimes, nonStandardInputReasons, test, ingestType);
   }
 
   @Override
@@ -1277,6 +1352,7 @@ public class Asset {
     sb.append("    resolutionTier: ").append(toIndentedString(resolutionTier)).append("\n");
     sb.append("    maxResolutionTier: ").append(toIndentedString(maxResolutionTier)).append("\n");
     sb.append("    encodingTier: ").append(toIndentedString(encodingTier)).append("\n");
+    sb.append("    videoQuality: ").append(toIndentedString(videoQuality)).append("\n");
     sb.append("    maxStoredFrameRate: ").append(toIndentedString(maxStoredFrameRate)).append("\n");
     sb.append("    aspectRatio: ").append(toIndentedString(aspectRatio)).append("\n");
     sb.append("    playbackIds: ").append(toIndentedString(playbackIds)).append("\n");

--- a/src/main/java/com/mux/sdk/models/CreateAssetRequest.java
+++ b/src/main/java/com/mux/sdk/models/CreateAssetRequest.java
@@ -222,7 +222,7 @@ public class CreateAssetRequest {
   private MaxResolutionTierEnum maxResolutionTier;
 
   /**
-   * The encoding tier informs the cost, quality, and available platform features for the asset. By default the &#x60;smart&#x60; encoding tier is used. [See the guide for more details.](https://docs.mux.com/guides/use-encoding-tiers)
+   * This field is deprecated. Please use &#x60;video_quality&#x60; instead. The encoding tier informs the cost, quality, and available platform features for the asset. By default the &#x60;smart&#x60; encoding tier is used. [See the video quality guide for more details.](https://docs.mux.com/guides/use-encoding-tiers)
    */
   @JsonAdapter(EncodingTierEnum.Adapter.class)
   public enum EncodingTierEnum {
@@ -271,6 +271,57 @@ public class CreateAssetRequest {
   public static final String SERIALIZED_NAME_ENCODING_TIER = "encoding_tier";
   @SerializedName(SERIALIZED_NAME_ENCODING_TIER)
   private EncodingTierEnum encodingTier;
+
+  /**
+   * The video quality controls the cost, quality, and available platform features for the asset. By default the &#x60;plus&#x60; video quality is used. This field replaces the deprecated &#x60;encoding_tier&#x60; value. [See the video quality guide for more details.](https://docs.mux.com/guides/use-encoding-tiers)
+   */
+  @JsonAdapter(VideoQualityEnum.Adapter.class)
+  public enum VideoQualityEnum {
+    BASIC("basic"),
+    
+    PLUS("plus");
+
+    private String value;
+
+    VideoQualityEnum(String value) {
+      this.value = value;
+    }
+
+    public String getValue() {
+      return value;
+    }
+
+    @Override
+    public String toString() {
+      return String.valueOf(value);
+    }
+
+    public static VideoQualityEnum fromValue(String value) {
+      for (VideoQualityEnum b : VideoQualityEnum.values()) {
+        if (b.value.equals(value)) {
+          return b;
+        }
+      }
+      throw new IllegalArgumentException("Unexpected value '" + value + "'");
+    }
+
+    public static class Adapter extends TypeAdapter<VideoQualityEnum> {
+      @Override
+      public void write(final JsonWriter jsonWriter, final VideoQualityEnum enumeration) throws IOException {
+        jsonWriter.value(enumeration.getValue());
+      }
+
+      @Override
+      public VideoQualityEnum read(final JsonReader jsonReader) throws IOException {
+        String value =  jsonReader.nextString();
+        return VideoQualityEnum.fromValue(value);
+      }
+    }
+  }
+
+  public static final String SERIALIZED_NAME_VIDEO_QUALITY = "video_quality";
+  @SerializedName(SERIALIZED_NAME_VIDEO_QUALITY)
+  private VideoQualityEnum videoQuality;
 
 
   public CreateAssetRequest input(java.util.List<InputSettings> input) {
@@ -534,11 +585,11 @@ public class CreateAssetRequest {
   }
 
    /**
-   * The encoding tier informs the cost, quality, and available platform features for the asset. By default the &#x60;smart&#x60; encoding tier is used. [See the guide for more details.](https://docs.mux.com/guides/use-encoding-tiers)
+   * This field is deprecated. Please use &#x60;video_quality&#x60; instead. The encoding tier informs the cost, quality, and available platform features for the asset. By default the &#x60;smart&#x60; encoding tier is used. [See the video quality guide for more details.](https://docs.mux.com/guides/use-encoding-tiers)
    * @return encodingTier
   **/
   @javax.annotation.Nullable
-  @ApiModelProperty(value = "The encoding tier informs the cost, quality, and available platform features for the asset. By default the `smart` encoding tier is used. [See the guide for more details.](https://docs.mux.com/guides/use-encoding-tiers)")
+  @ApiModelProperty(value = "This field is deprecated. Please use `video_quality` instead. The encoding tier informs the cost, quality, and available platform features for the asset. By default the `smart` encoding tier is used. [See the video quality guide for more details.](https://docs.mux.com/guides/use-encoding-tiers)")
 
   public EncodingTierEnum getEncodingTier() {
     return encodingTier;
@@ -547,6 +598,29 @@ public class CreateAssetRequest {
 
   public void setEncodingTier(EncodingTierEnum encodingTier) {
     this.encodingTier = encodingTier;
+  }
+
+
+  public CreateAssetRequest videoQuality(VideoQualityEnum videoQuality) {
+    
+    this.videoQuality = videoQuality;
+    return this;
+  }
+
+   /**
+   * The video quality controls the cost, quality, and available platform features for the asset. By default the &#x60;plus&#x60; video quality is used. This field replaces the deprecated &#x60;encoding_tier&#x60; value. [See the video quality guide for more details.](https://docs.mux.com/guides/use-encoding-tiers)
+   * @return videoQuality
+  **/
+  @javax.annotation.Nullable
+  @ApiModelProperty(value = "The video quality controls the cost, quality, and available platform features for the asset. By default the `plus` video quality is used. This field replaces the deprecated `encoding_tier` value. [See the video quality guide for more details.](https://docs.mux.com/guides/use-encoding-tiers)")
+
+  public VideoQualityEnum getVideoQuality() {
+    return videoQuality;
+  }
+
+
+  public void setVideoQuality(VideoQualityEnum videoQuality) {
+    this.videoQuality = videoQuality;
   }
 
 
@@ -569,12 +643,13 @@ public class CreateAssetRequest {
         Objects.equals(this.masterAccess, createAssetRequest.masterAccess) &&
         Objects.equals(this.test, createAssetRequest.test) &&
         Objects.equals(this.maxResolutionTier, createAssetRequest.maxResolutionTier) &&
-        Objects.equals(this.encodingTier, createAssetRequest.encodingTier);
+        Objects.equals(this.encodingTier, createAssetRequest.encodingTier) &&
+        Objects.equals(this.videoQuality, createAssetRequest.videoQuality);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(input, playbackPolicy, advancedPlaybackPolicies, perTitleEncode, passthrough, mp4Support, normalizeAudio, masterAccess, test, maxResolutionTier, encodingTier);
+    return Objects.hash(input, playbackPolicy, advancedPlaybackPolicies, perTitleEncode, passthrough, mp4Support, normalizeAudio, masterAccess, test, maxResolutionTier, encodingTier, videoQuality);
   }
 
   @Override
@@ -592,6 +667,7 @@ public class CreateAssetRequest {
     sb.append("    test: ").append(toIndentedString(test)).append("\n");
     sb.append("    maxResolutionTier: ").append(toIndentedString(maxResolutionTier)).append("\n");
     sb.append("    encodingTier: ").append(toIndentedString(encodingTier)).append("\n");
+    sb.append("    videoQuality: ").append(toIndentedString(videoQuality)).append("\n");
     sb.append("}");
     return sb.toString();
   }

--- a/src/main/java/com/mux/sdk/models/DeliveryReport.java
+++ b/src/main/java/com/mux/sdk/models/DeliveryReport.java
@@ -165,7 +165,7 @@ public class DeliveryReport {
   private AssetResolutionTierEnum assetResolutionTier;
 
   /**
-   * The encoding tier that the asset was ingested at. [See the encoding tiers guide for more details.](https://docs.mux.com/guides/use-encoding-tiers)
+   * This field is deprecated. Please use &#x60;asset_video_quality&#x60; instead. The encoding tier that the asset was ingested at. [See the video quality guide for more details.](https://docs.mux.com/guides/use-encoding-tiers)
    */
   @JsonAdapter(AssetEncodingTierEnum.Adapter.class)
   public enum AssetEncodingTierEnum {
@@ -214,6 +214,57 @@ public class DeliveryReport {
   public static final String SERIALIZED_NAME_ASSET_ENCODING_TIER = "asset_encoding_tier";
   @SerializedName(SERIALIZED_NAME_ASSET_ENCODING_TIER)
   private AssetEncodingTierEnum assetEncodingTier;
+
+  /**
+   * The video quality that the asset was ingested at. This field replaces &#x60;asset_encoding_tier&#x60;. [See the video quality guide for more details.](https://docs.mux.com/guides/use-encoding-tiers)
+   */
+  @JsonAdapter(AssetVideoQualityEnum.Adapter.class)
+  public enum AssetVideoQualityEnum {
+    BASIC("basic"),
+    
+    PLUS("plus");
+
+    private String value;
+
+    AssetVideoQualityEnum(String value) {
+      this.value = value;
+    }
+
+    public String getValue() {
+      return value;
+    }
+
+    @Override
+    public String toString() {
+      return String.valueOf(value);
+    }
+
+    public static AssetVideoQualityEnum fromValue(String value) {
+      for (AssetVideoQualityEnum b : AssetVideoQualityEnum.values()) {
+        if (b.value.equals(value)) {
+          return b;
+        }
+      }
+      throw new IllegalArgumentException("Unexpected value '" + value + "'");
+    }
+
+    public static class Adapter extends TypeAdapter<AssetVideoQualityEnum> {
+      @Override
+      public void write(final JsonWriter jsonWriter, final AssetVideoQualityEnum enumeration) throws IOException {
+        jsonWriter.value(enumeration.getValue());
+      }
+
+      @Override
+      public AssetVideoQualityEnum read(final JsonReader jsonReader) throws IOException {
+        String value =  jsonReader.nextString();
+        return AssetVideoQualityEnum.fromValue(value);
+      }
+    }
+  }
+
+  public static final String SERIALIZED_NAME_ASSET_VIDEO_QUALITY = "asset_video_quality";
+  @SerializedName(SERIALIZED_NAME_ASSET_VIDEO_QUALITY)
+  private AssetVideoQualityEnum assetVideoQuality;
 
   public static final String SERIALIZED_NAME_DELIVERED_SECONDS = "delivered_seconds";
   @SerializedName(SERIALIZED_NAME_DELIVERED_SECONDS)
@@ -415,11 +466,11 @@ public class DeliveryReport {
   }
 
    /**
-   * The encoding tier that the asset was ingested at. [See the encoding tiers guide for more details.](https://docs.mux.com/guides/use-encoding-tiers)
+   * This field is deprecated. Please use &#x60;asset_video_quality&#x60; instead. The encoding tier that the asset was ingested at. [See the video quality guide for more details.](https://docs.mux.com/guides/use-encoding-tiers)
    * @return assetEncodingTier
   **/
   @javax.annotation.Nullable
-  @ApiModelProperty(value = "The encoding tier that the asset was ingested at. [See the encoding tiers guide for more details.](https://docs.mux.com/guides/use-encoding-tiers)")
+  @ApiModelProperty(value = "This field is deprecated. Please use `asset_video_quality` instead. The encoding tier that the asset was ingested at. [See the video quality guide for more details.](https://docs.mux.com/guides/use-encoding-tiers)")
 
   public AssetEncodingTierEnum getAssetEncodingTier() {
     return assetEncodingTier;
@@ -428,6 +479,29 @@ public class DeliveryReport {
 
   public void setAssetEncodingTier(AssetEncodingTierEnum assetEncodingTier) {
     this.assetEncodingTier = assetEncodingTier;
+  }
+
+
+  public DeliveryReport assetVideoQuality(AssetVideoQualityEnum assetVideoQuality) {
+    
+    this.assetVideoQuality = assetVideoQuality;
+    return this;
+  }
+
+   /**
+   * The video quality that the asset was ingested at. This field replaces &#x60;asset_encoding_tier&#x60;. [See the video quality guide for more details.](https://docs.mux.com/guides/use-encoding-tiers)
+   * @return assetVideoQuality
+  **/
+  @javax.annotation.Nullable
+  @ApiModelProperty(value = "The video quality that the asset was ingested at. This field replaces `asset_encoding_tier`. [See the video quality guide for more details.](https://docs.mux.com/guides/use-encoding-tiers)")
+
+  public AssetVideoQualityEnum getAssetVideoQuality() {
+    return assetVideoQuality;
+  }
+
+
+  public void setAssetVideoQuality(AssetVideoQualityEnum assetVideoQuality) {
+    this.assetVideoQuality = assetVideoQuality;
   }
 
 
@@ -495,13 +569,14 @@ public class DeliveryReport {
         Objects.equals(this.assetDuration, deliveryReport.assetDuration) &&
         Objects.equals(this.assetResolutionTier, deliveryReport.assetResolutionTier) &&
         Objects.equals(this.assetEncodingTier, deliveryReport.assetEncodingTier) &&
+        Objects.equals(this.assetVideoQuality, deliveryReport.assetVideoQuality) &&
         Objects.equals(this.deliveredSeconds, deliveryReport.deliveredSeconds) &&
         Objects.equals(this.deliveredSecondsByResolution, deliveryReport.deliveredSecondsByResolution);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(liveStreamId, assetId, passthrough, createdAt, deletedAt, assetState, assetDuration, assetResolutionTier, assetEncodingTier, deliveredSeconds, deliveredSecondsByResolution);
+    return Objects.hash(liveStreamId, assetId, passthrough, createdAt, deletedAt, assetState, assetDuration, assetResolutionTier, assetEncodingTier, assetVideoQuality, deliveredSeconds, deliveredSecondsByResolution);
   }
 
   @Override
@@ -517,6 +592,7 @@ public class DeliveryReport {
     sb.append("    assetDuration: ").append(toIndentedString(assetDuration)).append("\n");
     sb.append("    assetResolutionTier: ").append(toIndentedString(assetResolutionTier)).append("\n");
     sb.append("    assetEncodingTier: ").append(toIndentedString(assetEncodingTier)).append("\n");
+    sb.append("    assetVideoQuality: ").append(toIndentedString(assetVideoQuality)).append("\n");
     sb.append("    deliveredSeconds: ").append(toIndentedString(deliveredSeconds)).append("\n");
     sb.append("    deliveredSecondsByResolution: ").append(toIndentedString(deliveredSecondsByResolution)).append("\n");
     sb.append("}");

--- a/src/main/java/com/mux/sdk/models/PlaybackPolicy.java
+++ b/src/main/java/com/mux/sdk/models/PlaybackPolicy.java
@@ -25,7 +25,7 @@ import com.google.gson.stream.JsonReader;
 import com.google.gson.stream.JsonWriter;
 
 /**
- * * &#x60;public&#x60; playback IDs are accessible by constructing an HLS URL like &#x60;https://stream.mux.com/${PLAYBACK_ID}&#x60;  * &#x60;signed&#x60; playback IDs should be used with tokens &#x60;https://stream.mux.com/${PLAYBACK_ID}?token&#x3D;{TOKEN}&#x60;. See [Secure video playback](https://docs.mux.com/guides/secure-video-playback) for details about creating tokens. 
+ * * &#x60;public&#x60; playback IDs are accessible by constructing an HLS URL like &#x60;https://stream.mux.com/${PLAYBACK_ID}&#x60;  * &#x60;signed&#x60; playback IDs should be used with tokens &#x60;https://stream.mux.com/${PLAYBACK_ID}?token&#x3D;{TOKEN}&#x60;. See [Secure video playback](https://docs.mux.com/guides/secure-video-playback) for details about creating tokens.  * &#x60;drm&#x60; playback IDs are protected with DRM technologies. [See DRM documentation for more details](https://docs.mux.com/guides/protect-videos-with-drm). 
  */
 @JsonAdapter(PlaybackPolicy.Adapter.class)
 public enum PlaybackPolicy {


### PR DESCRIPTION
 - support `video_quality` setting in place of deprecated `encoding_tier`. [Read more](https://www.mux.com/blog/no-one-said-naming-was-easy-encoding-tiers-are-now-video-quality-levels)
 - add support for DRM. [Read more](https://www.mux.com/blog/introducing-drm-the-latest-tool-in-protecting-your-content-on-mux)